### PR TITLE
Run add image content manifest plugin

### DIFF
--- a/inputs/worker_inner:6.json
+++ b/inputs/worker_inner:6.json
@@ -34,7 +34,7 @@
       "name": "add_help"
     },
     {
-      "name": "add_content_sets"
+      "name": "add_image_content_manifest"
     },
     {
       "name": "add_dockerfile"

--- a/osbs/build/plugins_configuration.py
+++ b/osbs/build/plugins_configuration.py
@@ -188,6 +188,13 @@ class PluginsConfigurationBase(object):
             self.pt.set_plugin_arg_valid(phase, plugin, 'koji_target',
                                          self.user_params.koji_target)
 
+    def render_add_image_content_manifest(self):
+        phase = 'prebuild_plugins'
+        plugin = 'add_image_content_manifest'
+        if self.pt.has_plugin_conf(phase, plugin):
+            self.pt.set_plugin_arg_valid(phase, plugin, 'remote_source_icm_url',
+                                         self.user_params.remote_source_icm_url)
+
     def render_add_labels_in_dockerfile(self):
         phase = 'prebuild_plugins'
         plugin = 'add_labels_in_dockerfile'
@@ -538,6 +545,7 @@ class PluginsConfiguration(PluginsConfigurationBase):
         self.render_koji_delegate()
         self.render_download_remote_source()
         self.render_resolve_remote_source()
+        self.render_add_image_content_manifest()
         return self.pt.to_json()
 
 

--- a/osbs/build/user_params.py
+++ b/osbs/build/user_params.py
@@ -313,6 +313,7 @@ class BuildUserParams(BuildCommon):
     release = BuildParam("release")
     remote_source_build_args = BuildParam("remote_source_build_args")
     remote_source_configs = BuildParam("remote_source_configs")
+    remote_source_icm_url = BuildParam("remote_source_icm_url")
     remote_source_url = BuildParam("remote_source_url")
     skip_build = BuildParam("skip_build")
     tags_from_yaml = BuildParam("tags_from_yaml")
@@ -359,6 +360,7 @@ class BuildUserParams(BuildCommon):
                     release=None,
                     remote_source_build_args=None,
                     remote_source_configs=None,
+                    remote_source_icm_url=None,
                     remote_source_url=None,
                     repo_info=None,
                     skip_build=None,
@@ -406,7 +408,12 @@ class BuildUserParams(BuildCommon):
         an environment variable into a worker build;
         when used, reactor_config_map is ignored.
         :param release: str,
-
+        :param remote_source_build_args: dict, extra args for `builder.build_args`, if any
+        :param remote_source_configs: list of str, configuration files to be injected into
+        the exploded remote sources dir
+        :param remote_source_icm_url: int, the Cachito ICM URL; used to request the
+        Image Content Manifest
+        :param remote_source_url: str, URL from which to download a source archive
         :param repo_info: RepoInfo, git repo data for the build
         :param scratch: bool, build as a scratch build
         :param signing_intent: bool, True to sign the resulting image
@@ -477,6 +484,7 @@ class BuildUserParams(BuildCommon):
             "release": release,
             "remote_source_build_args": remote_source_build_args,
             "remote_source_configs": remote_source_configs,
+            "remote_source_icm_url": remote_source_icm_url,
             "remote_source_url": remote_source_url,
             "skip_build": skip_build,
             "trigger_imagestreamtag": base_image,

--- a/tests/build_/test_arrangements.py
+++ b/tests/build_/test_arrangements.py
@@ -335,7 +335,7 @@ class TestArrangementV6(ArrangementBase):
                 'add_labels_in_dockerfile',
                 'change_from_in_dockerfile',
                 'add_help',
-                'add_content_sets',
+                'add_image_content_manifest',
                 'add_dockerfile',
                 'distgit_fetch_artefacts',
                 'fetch_maven_artifacts',

--- a/tests/constants.py
+++ b/tests/constants.py
@@ -45,7 +45,9 @@ TEST_DOCKERFILE_GIT = "https://github.com/TomasTomecek/docker-hello-world.git"
 TEST_DOCKERFILE_SHA1 = "6e592f1420efcd331cd28b360a7e02f669caf540"
 TEST_DOCKERFILE_INIT_SHA1 = "04523782eeb1e6c960b12f2f6fc887aa7cf76290"
 TEST_DOCKERFILE_BRANCH = "error-build"
-
+TEST_REMOTE_SOURCE_REQUEST_ID = 12345
+TEST_REMOTE_SOURCE_ICM_URL = ('http://cachito.example.com/api/v1/requests/{}/content-manifest'
+                              .format(TEST_REMOTE_SOURCE_REQUEST_ID))
 TEST_FLATPAK_BASE_IMAGE = 'registry.fedoraproject.org/fedora:latest'
 
 TEST_BUILD_JSON = {


### PR DESCRIPTION
Run new 'add_image_content_manifest' plugin
instead of 'add_content_sets' (keeping 'add_content_sets' in
place for now).

# Maintainers will complete the following section

- [ ] Commit messages are descriptive enough
- [ ] Code coverage from testing does not decrease and new code is covered
- [ ] JSON/YAML configuration changes are updated in the relevant schema
- [ ] Changes to metadata also update the documentation for the metadata
- [ ] Pull request has a link to an osbs-docs PR for user documentation updates
